### PR TITLE
Implement support for Phi-2 model

### DIFF
--- a/src/infer.cu
+++ b/src/infer.cu
@@ -525,7 +525,7 @@ static float* forward(struct Transformer* transformer, int token, int pos, unsig
 		if (p->arch == Phi) {
 			// self.w2(F.gelu(self.w1(x))) + pre-rmsnorm residual
 			kernel_matmul_ffn1_gelu<<<hidden_dim, 32>>>(s->hb, s->xb, (T*)w->w1[l], w->b1[l], dim, hidden_dim);
-			profiler_trigger("matmul_ffn1", 2 * hidden_dim * dim * sizeof(T));
+			profiler_trigger("matmul_ffn1", hidden_dim * dim * sizeof(T));
 		} else {
 			// self.w2(F.silu(self.w1(x)) * self.w3(x)) + pre-rmsnorm residual
 			kernel_matmul_ffn13_silu<<<hidden_dim, 32>>>(s->hb, s->xb, (T*)w->w1[l], (T*)w->w3[l], dim, hidden_dim);

--- a/src/model.h
+++ b/src/model.h
@@ -19,7 +19,13 @@ typedef short kvtype_t;
 // How many attention sinks to use for rolling buffer
 #define KV_SINKS 2
 
+enum Arch {
+	LlamaLike,
+	Phi
+};
+
 struct Config {
+	enum Arch arch;   // model architecture
 	int dim;          // transformer dimension
 	int hidden_dim;   // for ffn layers
 	int n_layers;     // number of layers
@@ -35,6 +41,9 @@ struct Weights {
 
 	// token embedding table
 	void* token_embedding_table; // (vocab_size, dim)
+	// weights for layernorm (phi)
+	float* ln_weight[MAX_LAYERS]; // (dim,)
+	float* ln_bias[MAX_LAYERS]; // (dim,)
 	// weights for rmsnorms
 	float* rms_att_weight[MAX_LAYERS]; // (dim) rmsnorm weights
 	float* rms_ffn_weight[MAX_LAYERS]; // (dim)
@@ -43,10 +52,13 @@ struct Weights {
 	void* wk[MAX_LAYERS]; // (dim, n_kv_heads * head_size)
 	void* wv[MAX_LAYERS]; // (dim, n_kv_heads * head_size)
 	void* wo[MAX_LAYERS]; // (n_heads * head_size, dim)
-	// weights for ffn
+	// weights for ffn (w3 is absent for phi)
 	void* w1[MAX_LAYERS]; // (hidden_dim, dim)
 	void* w2[MAX_LAYERS]; // (dim, hidden_dim)
 	void* w3[MAX_LAYERS]; // (hidden_dim, dim)
+	// final layernorm (phi)
+	float* ln_final_weight; // (dim,)
+	float* ln_final_bias; // (dim,)
 	// final rmsnorm
 	float* rms_final_weight; // (dim,)
 	// classifier weights for the logits, on the last layer

--- a/src/model.h
+++ b/src/model.h
@@ -63,6 +63,14 @@ struct Weights {
 	float* rms_final_weight; // (dim,)
 	// classifier weights for the logits, on the last layer
 	void* wcls;
+	// biases for all of the above (phi)
+	float* bq[MAX_LAYERS]; // (dim)
+	float* bk[MAX_LAYERS]; // (dim)
+	float* bv[MAX_LAYERS]; // (dim)
+	float* bo[MAX_LAYERS]; // (dim)
+	float* b1[MAX_LAYERS]; // (hidden_dim)
+	float* b2[MAX_LAYERS]; // (dim)
+	float* bcls;
 };
 
 struct RunState {

--- a/src/model.h
+++ b/src/model.h
@@ -34,6 +34,7 @@ struct Config {
 	int vocab_size;   // vocabulary size, usually 256 (byte-level)
 	int seq_len;      // max sequence length
 	float rope_theta; // RoPE theta
+	int rotary_dim;   // RoPE rotary dimension (elements after that don't get rotated)
 };
 
 struct Weights {

--- a/src/run.c
+++ b/src/run.c
@@ -205,7 +205,7 @@ void generate(struct Transformer* transformer, struct Tokenizer* tokenizer, stru
 
 	// print first prompt token since it won't be decoded
 	if (token != tokenizer->bos_id) {
-		char* piece = tokenizer_decode(tokenizer, token, tokenizer->bos_id);
+		char* piece = tokenizer_decode(tokenizer, tokenizer->bos_id, token);
 		printf("%s", piece);
 		fflush(stdout);
 	}

--- a/src/run.c
+++ b/src/run.c
@@ -78,6 +78,16 @@ void build_transformer(struct Config* config, struct Weights* weights, struct Te
 		if (config->arch != Phi) {
 			weights->w3[l] = tensors_get(tensors, "model.layers.%d.mlp.w3.weight", l, dtype, (int[]){config->hidden_dim, config->dim, 0, 0});
 		}
+
+		if (config->arch == Phi) {
+			weights->bq[l] = (float*)tensors_get(tensors, "model.layers.%d.attn.wq.bias", l, dt_f32, (int[]){config->dim, 0, 0, 0});
+			weights->bk[l] = (float*)tensors_get(tensors, "model.layers.%d.attn.wk.bias", l, dt_f32, (int[]){config->n_kv_heads * head_size, 0, 0, 0});
+			weights->bv[l] = (float*)tensors_get(tensors, "model.layers.%d.attn.wv.bias", l, dt_f32, (int[]){config->n_kv_heads * head_size, 0, 0, 0});
+			weights->bo[l] = (float*)tensors_get(tensors, "model.layers.%d.attn.wo.bias", l, dt_f32, (int[]){config->n_heads * head_size, 0, 0, 0});
+
+			weights->b1[l] = (float*)tensors_get(tensors, "model.layers.%d.mlp.w1.bias", l, dt_f32, (int[]){config->hidden_dim, 0, 0, 0});
+			weights->b2[l] = (float*)tensors_get(tensors, "model.layers.%d.mlp.w2.bias", l, dt_f32, (int[]){config->dim, 0, 0, 0});
+		}
 	}
 
 	if (config->arch == Phi) {
@@ -88,6 +98,10 @@ void build_transformer(struct Config* config, struct Weights* weights, struct Te
 	}
 
 	weights->wcls = tensors_get(tensors, "model.output.weight", 0, dtype, (int[]){config->vocab_size, config->dim, 0, 0});
+
+	if (config->arch == Phi) {
+		weights->bcls = (float*)tensors_get(tensors, "model.output.bias", 0, dt_f32, (int[]){config->vocab_size, 0, 0, 0});
+	}
 }
 
 void build_tokenizer(struct Tokenizer* t, struct Tensors* tensors, int vocab_size) {

--- a/src/run.c
+++ b/src/run.c
@@ -48,6 +48,9 @@ void build_transformer(struct Config* config, struct Weights* weights, struct Te
 	const char* rope_theta = tensors_metadata_find(tensors, "rope_theta");
 	config->rope_theta = rope_theta ? atof(rope_theta) : 10000.f;
 
+	const char* rotary_dim = tensors_metadata_find(tensors, "rotary_dim");
+	config->rotary_dim = rotary_dim ? atoi(rotary_dim) : config->dim / config->n_heads;
+
 	int head_size = config->dim / config->n_heads;
 
 	struct Tensor* tensor = tensors_find(tensors, "model.embed.weight", 0);

--- a/src/run.c
+++ b/src/run.c
@@ -143,7 +143,9 @@ size_t model_bandwidth(struct Config* config, size_t dsize) {
 	// weights for ffn
 	res += dsize * config->hidden_dim * config->dim * config->n_layers;
 	res += dsize * config->dim * config->hidden_dim * config->n_layers;
-	res += dsize * config->hidden_dim * config->dim * config->n_layers;
+	if (config->arch != Phi) {
+		res += dsize * config->hidden_dim * config->dim * config->n_layers;
+	}
 	// final rmsnorm
 	res += sizeof(float) * config->dim;
 	// classifier weights for the logits, on the last layer

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MAX_TOKEN_LENGTH 128
+#define MAX_TOKEN_LENGTH 256
 
 static int compare_tokens(const void* a, const void* b) {
 	return strcmp(((struct TokenIndex*)a)->str, ((struct TokenIndex*)b)->str);

--- a/tools/convert.py
+++ b/tools/convert.py
@@ -204,11 +204,11 @@ elif arch == "phi":
         assert wkv_w.shape[0] == 3 * dim and wkv_b.shape[0] == 3 * dim
 
         tensors[f"model.layers.{l}.attn.wq.weight"] = conv(permute_reverse(wkv_w[:dim], config["n_head"]))
-        tensors[f"model.layers.{l}.attn.wq.bias"] = conv(permute_reverse(wkv_b[:dim], config["n_head"]))
+        tensors[f"model.layers.{l}.attn.wq.bias"] = permute_reverse(wkv_b[:dim], config["n_head"]).float()
         tensors[f"model.layers.{l}.attn.wk.weight"] = conv(permute_reverse(wkv_w[dim:dim*2], config["n_head"]))
-        tensors[f"model.layers.{l}.attn.wk.bias"] = conv(permute_reverse(wkv_b[dim:dim*2], config["n_head"]))
+        tensors[f"model.layers.{l}.attn.wk.bias"] = permute_reverse(wkv_b[dim:dim*2], config["n_head"]).float()
         tensors[f"model.layers.{l}.attn.wv.weight"] = conv(wkv_w[dim*2:])
-        tensors[f"model.layers.{l}.attn.wv.bias"] = conv(wkv_b[dim*2:])
+        tensors[f"model.layers.{l}.attn.wv.bias"] = wkv_b[dim*2:].float()
 
         tensors[f"model.layers.{l}.attn.wo.weight"] = conv(weights[f"transformer.h.{l}.mixer.out_proj.weight"])
         tensors[f"model.layers.{l}.attn.wo.bias"] = weights[f"transformer.h.{l}.mixer.out_proj.bias"].float()


### PR DESCRIPTION
This is the first new architecture that's substantially different in that it doesn't fit into the normal flow. It uses layernorm, all linear layers have biases, and MLP starts from the initial layer state instead of the post-attention projection. The latter is interesting in that it gives us potential for more parallelism during inference on GPU.

This implementation is unoptimized and a little messy, but it will be easier to improve on top of it. It was structured to minimize the changes to Llama like architectures, although we did end up having to revert the power-of-two-head-size optimization that might be valuable to bring back in the future.