### PR TITLE
Optional compile time support for half-precision matmul

### DIFF
--- a/src/helpers.cuh
+++ b/src/helpers.cuh
@@ -76,6 +76,18 @@ __device__ inline float4 fp8x4_e5m2_ff(__nv_fp8x4_e5m2 v) {
 #endif
 }
 
+// fast fp8x2 => half2 conversion; drops unnecessary NaN handling from __nv_cvt_fp8_to_halfraw
+__device__ inline half2 fp8x2_e5m2_ff(unsigned int v) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+	__nv_fp8x2_e5m2 p;
+	p.__x = v;
+	return half2(p);
+#else
+	__half2_raw h = {(unsigned short)(v << 8), (unsigned short)(v & 0xff00)};
+	return h;
+#endif
+}
+
 __device__ inline float fp8_e5m2_ff(uint8_t v) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
 	__half_raw h = __nv_cvt_fp8_to_halfraw(v, __NV_E5M2);
@@ -149,6 +161,27 @@ __device__ inline float matmul_warppar(float* x, __nv_fp8_e5m2* w, int i, int n)
 		}
 	}
 	return warpreduce_sum(val);
+}
+
+// warp-parallel mat*vec; each warp collaboratively computes mat*vec for a single row
+// specialized for fp8 weights and ensures that we maximize transaction sizes by reading 4 bytes per thread
+__device__ inline float matmul_warppar(half* x, __nv_fp8_e5m2* w, int i, int n) {
+	int lane = threadIdx.x % warpSize;
+	half2 val = {0, 0};
+	// use 64-bit loads instead of 32-bit loads to increase memory throughput on H100/A100
+	// without this we are seeing lower throughput given the limited number of parallel warps in coop kernel
+	// this is performance-neutral on 4090 but results in issues with x[] load coalescing (that are benign)
+	for (int j = lane * 8; j < n; j += warpSize * 8) {
+		ablock<__nv_fp8x2_e5m2, 4> wwp = *(ablock<__nv_fp8x2_e5m2, 4>*)&w[i * n + j];
+		ablock<__half2_raw, 4> xxp = *(ablock<__half2_raw, 4>*)&x[j];
+#pragma unroll
+		for (int k = 0; k < 4; ++k) {
+			half2 ww = fp8x2_e5m2_ff(wwp.v[k].__x);
+			half2 xx = xxp.v[k];
+			val = __hfma2(ww, xx, val);
+		}
+	}
+	return warpreduce_sum(float(val.x + val.y));
 }
 
 // warp-parallel mat*vec; each warp collaboratively computes mat*vec for a single row

--- a/src/infer.cu
+++ b/src/infer.cu
@@ -312,10 +312,14 @@ __device__ static float rmsnorm(T* o, float* x, float* weight, int size, float e
 
 	// calculate sum of squares (per thread)
 	float ss = 0.0f;
-	for (int j = i; j < size; j += blockSize) {
-		float v = x[j] - mean;
-		ss += v * v;
-		o[j] = v * weight[j];
+	for (int j = i * 2; j < size; j += blockSize * 2) {
+		float2 xx = *(float2*)&x[j];
+		float2 ww = *(float2*)&weight[j];
+		float v0 = xx.x - mean;
+		float v1 = xx.y - mean;
+		ss += v0 * v0;
+		ss += v1 * v1;
+		*(ablock<T, 2>*)&o[j] = { v0 * ww.x, v1 * ww.y };
 	}
 
 	// sum across threads in block

--- a/src/infer.cu
+++ b/src/infer.cu
@@ -293,7 +293,8 @@ __device__ static void softmax(float* xout, float* x, int size) {
 	}
 }
 
-__device__ static float rmsnorm(float* o, float* x, float* weight, int size, float eps, bool ln) {
+template <typename T>
+__device__ static float rmsnorm(T* o, float* x, float* weight, int size, float eps, bool ln) {
 	int i = threadIdx.x;
 	int blockSize = blockDim.x;
 
@@ -395,13 +396,15 @@ __device__ static void coopstage(uint64_t* stats, int stage) {
 	}
 }
 
-template <typename T, typename KVT>
+template <typename T, typename KVT, typename AT>
 __global__ __launch_bounds__(1024, 1) static void kernel_forward(const __grid_constant__ CoopArgs<T, KVT> args) {
-	extern __shared__ float xs[];
+	extern __shared__ char smem[];
 	__shared__ float rmsscale;
 
 	__shared__ float moe_weights[32];
 	__shared__ int moe_experts[32];
+
+	AT* xs = (AT*)smem;
 
 	int dim = args.dim;
 	int hidden_dim = args.hidden_dim;
@@ -611,9 +614,11 @@ __global__ __launch_bounds__(1024, 1) static void kernel_forward(const __grid_co
 	}
 }
 
-template <typename T>
+template <typename T, typename AT>
 __global__ static void kernel_output(uint64_t, float* xout, float* x, T* w, float* rms_weight, int n, int d, float norm_eps, bool norm_ln) {
-	extern __shared__ float xs[];
+	extern __shared__ char smem[];
+
+	AT* xs = (AT*)smem;
 
 	float rmsscale = rmsnorm(xs, x, rms_weight, n, norm_eps, norm_ln);
 
@@ -632,7 +637,7 @@ __global__ static void kernel_output(uint64_t, float* xout, float* x, T* w, floa
 	}
 }
 
-template <typename T, typename KVT>
+template <typename T, typename KVT, typename AT = float>
 static float* forward(struct Transformer* transformer, int token, int pos, unsigned flags) {
 	struct Config* p = &transformer->config;
 	struct Weights* w = &transformer->weights;
@@ -703,7 +708,7 @@ static float* forward(struct Transformer* transformer, int token, int pos, unsig
 	};
 	void* argsp = &args;
 
-	CUDA_CHECK(cudaLaunchCooperativeKernel((void*)kernel_forward<T, KVT>, coopsms, 1024, &argsp, dim * sizeof(float), stream));
+	CUDA_CHECK(cudaLaunchCooperativeKernel((void*)kernel_forward<T, KVT, AT>, coopsms, 1024, &argsp, dim * sizeof(float), stream));
 
 	if (flags & FF_UPDATE_KV_ONLY) {
 		// only update kv cache and don't output logits
@@ -712,10 +717,10 @@ static float* forward(struct Transformer* transformer, int token, int pos, unsig
 
 	int output_blk = 32 * 32;
 	int output_par = 1;
-	CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&output_par, kernel_output<T>, output_blk, dim * sizeof(float)));
+	CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&output_par, kernel_output<T, AT>, output_blk, dim * sizeof(float)));
 
 	// classifier into logits
-	kernel_output<<<coopsms * output_par, output_blk, dim * sizeof(float), stream>>>(
+	kernel_output<T, AT><<<coopsms * output_par, output_blk, dim * sizeof(float), stream>>>(
 	    PROF_TOKEN(p->vocab_size * dim * dbits / 8), s->logits, x, (T*)w->wcls, w->rms_final_weight, dim, p->vocab_size, p->norm_eps, p->norm_ln);
 
 	CUDA_CHECK(cudaStreamSynchronize(stream));
@@ -725,16 +730,16 @@ static float* forward(struct Transformer* transformer, int token, int pos, unsig
 }
 
 extern "C" float* forward_cuda(struct Transformer* transformer, int token, int pos, unsigned flags) {
-#define CASE(dbits_, dtype, kvbits_, kvtype)                                          \
+#define CASE(dbits_, dtype, kvbits_, kvtype, atype)                                   \
 	if (transformer->weights.dbits == dbits_ && transformer->state.kvbits == kvbits_) \
-	return forward<dtype, kvtype>(transformer, token, pos, flags)
+	return forward<dtype, kvtype, atype>(transformer, token, pos, flags)
 
-	CASE(4, uint32_t, 8, __nv_fp8_e5m2);
-	CASE(4, uint32_t, 16, __half);
-	CASE(8, __nv_fp8_e5m2, 8, __nv_fp8_e5m2);
-	CASE(8, __nv_fp8_e5m2, 16, __half);
-	CASE(16, __half, 8, __nv_fp8_e5m2);
-	CASE(16, __half, 16, __half);
+	CASE(4, uint32_t, 8, __nv_fp8_e5m2, float);
+	CASE(4, uint32_t, 16, __half, float);
+	CASE(8, __nv_fp8_e5m2, 8, __nv_fp8_e5m2, float);
+	CASE(8, __nv_fp8_e5m2, 16, __half, float);
+	CASE(16, __half, 8, __nv_fp8_e5m2, float);
+	CASE(16, __half, 16, __half, float);
 
 	assert(!"Unsupported dbits/kvbits combination for CUDA: dbits must be 4, 8 or 16, kvbits must be 8 or 16");
 	return NULL;


### PR DESCRIPTION
Instead of always assuming matmul() is using float xs[], this adds optional support for half-precision activations to improve compute density. This only has a marginal effect (no effect on 4090, +0.5% on H100) and the bulk of the effect seems to be the 2-at-a-time rmsnorm processing, but this might be useful in the future as it ensures that matmul functions are optimally compute-dense.

Note that this isn't supported for gf4 weights atm to avoid complications with lowering; gf4 probably needs to be restructured to properly take advantage of this in the future.