### PR TITLE
Implement initial Metal port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,10 @@ jobs:
       run: |
         export NVCC=/usr/local/cuda/bin/nvcc
         make -j2
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: make
+      run: make -j2

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ ifeq ($(UNAME),Darwin)
   CFLAGS+=-Xclang -fopenmp -I/opt/homebrew/opt/libomp/include
   LDFLAGS+=-L/opt/homebrew/opt/libomp/lib -lomp
   LDFLAGS+=-framework Metal -framework Foundation
+  METALFLAGS=-std=metal3.0 -O2
 else
   CFLAGS+=-fopenmp -mf16c -mavx2 -mfma
   LDFLAGS+=-fopenmp
@@ -76,7 +77,7 @@ $(BUILD)/%.m.o: %.m
 
 $(BUILD)/%.metal.o: %.metal
 	@mkdir -p $(dir $@)
-	xcrun metal $< -O2 -c -MMD -MP -o $@.ir
+	xcrun metal $< $(METALFLAGS) -c -MMD -MP -o $@.ir
 	xcrun metallib -o $@.metallib $@.ir
 	xxd -i -n $(basename $(notdir $<))_metallib $@.metallib > $@.c
 	$(CC) $@.c -c -o $@

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,10 @@ CFLAGS=-g -Wall -Wpointer-arith -Werror -O3 -ffast-math
 LDFLAGS=-lm
 
 ifeq ($(UNAME),Darwin)
-  CFLAGS+=-Xclang -fopenmp -I/opt/homebrew/opt/libomp/include
-  LDFLAGS+=-L/opt/homebrew/opt/libomp/lib -lomp
+  ifneq (,$(wildcard /opt/homebrew/opt/libomp))
+    CFLAGS+=-Xclang -fopenmp -I/opt/homebrew/opt/libomp/include
+    LDFLAGS+=-L/opt/homebrew/opt/libomp/lib -lomp
+  endif
   LDFLAGS+=-framework Metal -framework Foundation
   METALFLAGS=-std=metal3.0 -O2
 else

--- a/src/infer.m
+++ b/src/infer.m
@@ -171,7 +171,7 @@ float* forward_metal(struct Transformer* transformer, int token, int pos, unsign
 		// qkv
 		assert(w->bqkv[l] == NULL); // TODO
 
-		dispatch(encoder, "qkv", "half_half", q_dim + kv_dim * 2, 32, &(struct QkvArgs) { dim, q_dim, kv_dim, p->head_dim, p->rotary_dim, pos, kv_pos, p->seq_len, loff, p->qkv_clip, log2(p->rope_theta) }, sizeof(struct QkvArgs), (void*[]) { s->xb, s->q, s->key_cache, s->value_cache, w->wq[l], w->wk[l], w->wv[l] }, 7);
+		dispatch(encoder, "qkv", "half_half", (q_dim + kv_dim * 2) / 2, 32, &(struct QkvArgs) { dim, q_dim, kv_dim, p->head_dim, p->rotary_dim, pos, kv_pos, p->seq_len, loff, p->qkv_clip, log2(p->rope_theta) }, sizeof(struct QkvArgs), (void*[]) { s->xb, s->q, s->key_cache, s->value_cache, w->wq[l], w->wk[l], w->wv[l] }, 7);
 
 		// attn score
 		int kv_lent = (kv_len + 7) / 8;

--- a/src/infer.m
+++ b/src/infer.m
@@ -169,7 +169,9 @@ float* forward_metal(struct Transformer* transformer, int token, int pos, unsign
 		dispatch(encoder, "rmsnorm", NULL, 1, 1024, &(struct NormArgs) { dim, p->norm_eps, p->norm_ln }, sizeof(struct NormArgs), (void*[]) { s->xb, x, w->rms_att_weight[l] }, 3);
 
 		// qkv
-		dispatch(encoder, "qkv", "half_half", dim, 32, &(struct QkvArgs) { dim, q_dim, kv_dim, p->head_dim, p->rotary_dim, pos, kv_pos, p->seq_len, loff, p->qkv_clip, log2(p->rope_theta) }, sizeof(struct QkvArgs), (void*[]) { s->xb, s->q, s->key_cache, s->value_cache, w->wq[l], w->wk[l], w->wv[l], w->bqkv[l] }, 8);
+		assert(w->bqkv[l] == NULL); // TODO
+
+		dispatch(encoder, "qkv", "half_half", dim, 32, &(struct QkvArgs) { dim, q_dim, kv_dim, p->head_dim, p->rotary_dim, pos, kv_pos, p->seq_len, loff, p->qkv_clip, log2(p->rope_theta) }, sizeof(struct QkvArgs), (void*[]) { s->xb, s->q, s->key_cache, s->value_cache, w->wq[l], w->wk[l], w->wv[l] }, 7);
 
 		// attn score
 		int kv_lent = (kv_len + 7) / 8;

--- a/src/infer.m
+++ b/src/infer.m
@@ -171,7 +171,7 @@ float* forward_metal(struct Transformer* transformer, int token, int pos, unsign
 		// qkv
 		assert(w->bqkv[l] == NULL); // TODO
 
-		dispatch(encoder, "qkv", "half_half", dim, 32, &(struct QkvArgs) { dim, q_dim, kv_dim, p->head_dim, p->rotary_dim, pos, kv_pos, p->seq_len, loff, p->qkv_clip, log2(p->rope_theta) }, sizeof(struct QkvArgs), (void*[]) { s->xb, s->q, s->key_cache, s->value_cache, w->wq[l], w->wk[l], w->wv[l] }, 7);
+		dispatch(encoder, "qkv", "half_half", q_dim + kv_dim * 2, 32, &(struct QkvArgs) { dim, q_dim, kv_dim, p->head_dim, p->rotary_dim, pos, kv_pos, p->seq_len, loff, p->qkv_clip, log2(p->rope_theta) }, sizeof(struct QkvArgs), (void*[]) { s->xb, s->q, s->key_cache, s->value_cache, w->wq[l], w->wk[l], w->wv[l] }, 7);
 
 		// attn score
 		int kv_lent = (kv_len + 7) / 8;

--- a/src/infer.m
+++ b/src/infer.m
@@ -9,87 +9,124 @@ static id<MTLDevice> device;
 static id<MTLCommandQueue> queue;
 static id<MTLComputePipelineState> kernels[256];
 
-static void dispatch(id<MTLComputeCommandEncoder> encoder, unsigned int thread_groups, unsigned int thread_group_size, const char* name, void* params, size_t params_size, void** buffers, size_t buffer_count) {
-    id<MTLComputePipelineState> state = nil;
-    for (size_t i = 0; kernels[i]; ++i) {
-        if (strcmp(kernels[i].label.UTF8String, name) == 0) {
-            state = kernels[i];
-            break;
-        }
-    }
-    assert(state);
+static void dispatch(id<MTLComputeCommandEncoder> encoder, const char* name, const char* variant, unsigned int thread_groups, unsigned int thread_group_size, void* params, size_t params_size, void** buffers, size_t buffer_count) {
+	char expected[256];
+	strcpy(expected, name);
+	if (variant) {
+		strcat(expected, "_");
+		strcat(expected, variant);
+	}
 
-    [encoder setComputePipelineState:state];
-    [encoder setBytes:params length:params_size atIndex:0];
-    for (size_t i = 0; i < buffer_count; ++i) {
-        [encoder setBuffer:buffers[i] offset:0 atIndex:i+1];
-    }
+	id<MTLComputePipelineState> state = nil;
+	for (size_t i = 0; kernels[i]; ++i) {
+		if (strcmp(kernels[i].label.UTF8String, expected) == 0) {
+			state = kernels[i];
+			break;
+		}
+	}
+	assert(state);
 
-    [encoder dispatchThreadgroups:MTLSizeMake(thread_groups, 1, 1) threadsPerThreadgroup:MTLSizeMake(thread_group_size, 1, 1)];
+	[encoder setComputePipelineState:state];
+	[encoder setBytes:params length:params_size atIndex:0];
+	for (size_t i = 0; i < buffer_count; ++i) {
+		[encoder setBuffer:buffers[i] offset:0 atIndex:i+1];
+	}
+
+	[encoder dispatchThreadgroups:MTLSizeMake(thread_groups, 1, 1) threadsPerThreadgroup:MTLSizeMake(thread_group_size, 1, 1)];
 }
 
 void init_metal(void) {
-    NSArray<id<MTLDevice>>* devices = MTLCopyAllDevices();
-    assert(devices.count > 0);
+	NSArray<id<MTLDevice>>* devices = MTLCopyAllDevices();
+	assert(devices.count > 0);
 
-    device = devices[0];
-    queue = [device newCommandQueue];
+	device = devices[0];
+	queue = [device newCommandQueue];
 
-    dispatch_data_t lib_data = dispatch_data_create(infer_metallib, infer_metallib_len, dispatch_get_main_queue(), ^{});
+	dispatch_data_t lib_data = dispatch_data_create(infer_metallib, infer_metallib_len, dispatch_get_main_queue(), ^{});
 
-    NSError *error = nil;
-    id<MTLLibrary> library = [device newLibraryWithData:lib_data error:&error];
-    assert(library);
+	NSError *error = nil;
+	id<MTLLibrary> library = [device newLibraryWithData:lib_data error:&error];
+	assert(library);
 
-    NSArray<NSString*>* functions = library.functionNames;
-    for (size_t i = 0; i < functions.count; i++) {
-        MTLComputePipelineDescriptor* descriptor = [MTLComputePipelineDescriptor alloc];
-        descriptor.computeFunction = [library newFunctionWithName:functions[i]];
-        descriptor.label = functions[i];
+	NSArray<NSString*>* functions = library.functionNames;
+	for (size_t i = 0; i < functions.count; i++) {
+		MTLComputePipelineDescriptor* descriptor = [MTLComputePipelineDescriptor alloc];
+		descriptor.computeFunction = [library newFunctionWithName:functions[i]];
+		descriptor.label = functions[i];
 
-        id<MTLComputePipelineState> computePipelineState = [device newComputePipelineStateWithDescriptor:descriptor options:MTLPipelineOptionNone reflection:nil error:&error];
-        assert(computePipelineState);
-        kernels[i] = computePipelineState;
-    }
+		id<MTLComputePipelineState> computePipelineState = [device newComputePipelineStateWithDescriptor:descriptor options:MTLPipelineOptionNone reflection:nil error:&error];
+		assert(computePipelineState);
+		kernels[i] = computePipelineState;
+	}
 }
 
 void* upload_metal(void* host, size_t size) {
-    assert(device);
-    id<MTLBuffer> buffer = [device newBufferWithBytes:host length:size options:MTLResourceStorageModeShared];
-    return buffer;
+	assert(device);
+	id<MTLBuffer> buffer = [device newBufferWithBytes:host length:size options:MTLResourceStorageModeShared];
+	return buffer;
+}
+
+static void* newbuffer(size_t size) {
+	return [device newBufferWithLength:size options:MTLResourceStorageModeShared];
 }
 
 void prepare_metal(struct Transformer* transformer) {
-    assert(device);
-    printf("# Metal: %s\n", device.name.UTF8String);
+	struct Config* config = &transformer->config;
+	struct RunState* state = &transformer->state;
 
-    // Create buffers for input and output data
-    float inputData[] = {1.0, 2.0, 3.0, 4.0};
-    float outputData[4] = {0};
-    float scale = 0.5;
-    id<MTLBuffer> inputBuffer = [device newBufferWithBytes:inputData length:sizeof(inputData) options:MTLResourceStorageModeShared];
-    id<MTLBuffer> outputBuffer = [device newBufferWithBytes:outputData length:sizeof(outputData) options:MTLResourceStorageModeShared];
-    
-    // Create a command buffer
-    id<MTLCommandBuffer> commandBuffer = [queue commandBuffer];
-    
-    // Create a compute command encoder
-    id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoder];
+	assert(device);
+	printf("# Metal: %s\n", device.name.UTF8String);
 
-    dispatch(computeEncoder, 1, 4, "kernel_basic", &scale, sizeof(scale), (void*[]){ inputBuffer, outputBuffer }, 2);
-    
-    // End encoding and commit the command buffer
-    [computeEncoder endEncoding];
-    [commandBuffer commit];
-    [commandBuffer waitUntilCompleted];
-    
-    // Read back the data
-    memcpy(outputData, outputBuffer.contents, sizeof(outputData));
-    for (int i = 0; i < 4; i++) {
-        NSLog(@"Output %d: %f", i, outputData[i]);
-    }
+	int dim = config->dim;
+	int hidden_dim = config->hidden_dim;
+	int q_dim = config->head_dim * config->n_heads;
+	int kv_dim = config->head_dim * config->n_kv_heads;
+
+	state->x = (float*)newbuffer(dim * sizeof(float));
+	state->hb = (float*)newbuffer(hidden_dim * sizeof(float));
+	state->he = (float*)newbuffer(config->n_experts_ac * hidden_dim * sizeof(float));
+	state->q = (float*)newbuffer(q_dim * sizeof(float));
+	state->att = (float*)newbuffer(config->n_heads * config->seq_len * 2 * sizeof(float));
+
+	assert(state->kvbits == 8 || state->kvbits == 16);
+	state->key_cache = newbuffer((size_t)config->n_layers * config->seq_len * kv_dim * (state->kvbits / 8));
+	state->value_cache = newbuffer((size_t)config->n_layers * config->seq_len * kv_dim * (state->kvbits / 8));
+
+	// logits are going to be read by the host so we just allocate them in host and write to host directly
+	state->logits = (float*)newbuffer(config->vocab_size * sizeof(float));
 }
 
 float* forward_metal(struct Transformer* transformer, int token, int pos, unsigned flags) {
-    return NULL;
+	struct Config* p = &transformer->config;
+	struct Weights* w = &transformer->weights;
+	struct RunState* s = &transformer->state;
+
+	// a few convenience variables
+	float* x = s->x;
+	int dim = p->dim;
+	int hidden_dim = p->hidden_dim;
+	int kv_dim = p->head_dim * p->n_kv_heads;
+
+	// ensure all dimensions are warp-aligned
+	assert(dim % 32 == 0 && kv_dim % 32 == 0 && hidden_dim % 32 == 0);
+
+	// begin command recording
+	id<MTLCommandBuffer> commands = [queue commandBufferWithUnretainedReferences];
+	id<MTLComputeCommandEncoder> encoder = [commands computeCommandEncoder];
+
+	// copy the token embedding into x
+	assert(token < p->vocab_size);
+	dispatch(encoder, "embed", "half", dim / 32, 32, (int[]){ token * dim }, sizeof(int), (void*[]){ x, w->token_embedding_table }, 2);
+
+	// submit commands and wait
+	[encoder endEncoding];
+	[commands commit];
+	[commands waitUntilCompleted];
+
+	if (flags & FF_UPDATE_KV_ONLY) {
+		// only update kv cache and don't output logits
+		return NULL;
+	}
+
+	return [(id<MTLBuffer>)s->logits contents];
 }

--- a/src/infer.m
+++ b/src/infer.m
@@ -1,0 +1,68 @@
+#include <Metal/Metal.h>
+
+extern unsigned char infer_metallib[];
+extern unsigned int infer_metallib_len;
+
+// Main function to setup and run the Metal compute kernel
+void testmetal() {
+    // Create a device
+    NSArray <id<MTLDevice>>* mtl_devices = MTLCopyAllDevices();
+    assert(mtl_devices.count > 0);
+    id<MTLDevice> device = mtl_devices[0];
+
+    dispatch_data_t lib_data = dispatch_data_create(infer_metallib, infer_metallib_len, dispatch_get_main_queue(), ^{});
+    
+    // Load the kernel function from default library
+    NSError *error = nil;
+    id<MTLLibrary> defaultLibrary = [device newLibraryWithData:lib_data error:&error];
+    id<MTLFunction> kernelFunction = [defaultLibrary newFunctionWithName:@"kernel_basic"];
+    
+    // Create a compute pipeline state
+    id<MTLComputePipelineState> computePipelineState = [device newComputePipelineStateWithFunction:kernelFunction error:&error];
+    if (!computePipelineState) {
+        NSLog(@"Failed to create compute pipeline state: %@", error);
+        return;
+    }
+    
+    // Create a command queue
+    id<MTLCommandQueue> commandQueue = [device newCommandQueue];
+    
+    // Create buffers for input and output data
+    float inputData[] = {1.0, 2.0, 3.0, 4.0};
+    float outputData[4] = {0};
+    float scale = 0.5;
+    id<MTLBuffer> inputBuffer = [device newBufferWithBytes:inputData length:sizeof(inputData) options:MTLResourceStorageModeShared];
+    id<MTLBuffer> outputBuffer = [device newBufferWithBytes:outputData length:sizeof(outputData) options:MTLResourceStorageModeShared];
+    id<MTLBuffer> scaleBuffer = [device newBufferWithBytes:&scale length:sizeof(scale) options:MTLResourceStorageModeShared];
+    
+    // Create a command buffer
+    id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
+    
+    // Create a compute command encoder
+    id<MTLComputeCommandEncoder> computeEncoder = [commandBuffer computeCommandEncoder];
+    [computeEncoder setComputePipelineState:computePipelineState];
+    [computeEncoder setBuffer:inputBuffer offset:0 atIndex:0];
+    [computeEncoder setBuffer:outputBuffer offset:0 atIndex:1];
+    [computeEncoder setBuffer:scaleBuffer offset:0 atIndex:2];
+    
+    // Dispatch the compute kernel
+    MTLSize gridSize = MTLSizeMake(4, 1, 1); // Process the 4 elements
+    NSUInteger threadGroupSize = computePipelineState.maxTotalThreadsPerThreadgroup;
+    if (threadGroupSize > gridSize.width) {
+        threadGroupSize = gridSize.width;
+    }
+    MTLSize threadgroupSize = MTLSizeMake(threadGroupSize, 1, 1);
+    [computeEncoder dispatchThreads:gridSize threadsPerThreadgroup:threadgroupSize];
+    
+    // End encoding and commit the command buffer
+    [computeEncoder endEncoding];
+    [commandBuffer commit];
+    [commandBuffer waitUntilCompleted];
+    
+    // Read back the data
+    memcpy(outputData, outputBuffer.contents, sizeof(outputData));
+    for (int i = 0; i < 4; i++) {
+        NSLog(@"Output %d: %f", i, outputData[i]);
+    }
+}
+

--- a/src/infer.m
+++ b/src/infer.m
@@ -142,10 +142,9 @@ float* forward_metal(struct Transformer* transformer, int token, int pos, unsign
 	int kv_dim = p->head_dim * p->n_kv_heads;
 	int q_dim = p->head_dim * p->n_heads;
 	int kv_mul = p->n_heads / p->n_kv_heads;
-	assert(w->dbits == 16 || w->dbits == 8); // TODO
 	assert(s->kvbits == 16); // TODO
 
-	const char* dvar = w->dbits == 16 ? "half" : (w->dbits == 8 ? "fp8" : "?");
+	const char* dvar = w->dbits == 16 ? "half" : (w->dbits == 8 ? "fp8" : (w->dbits == 4 ? "gf4" : "?"));
 	const char* kvar = "half";
 
 	char dkvar[32];

--- a/src/infer.m
+++ b/src/infer.m
@@ -1,14 +1,28 @@
+#include "model.h"
+
 #include <Metal/Metal.h>
 
 extern unsigned char infer_metallib[];
 extern unsigned int infer_metallib_len;
 
-// Main function to setup and run the Metal compute kernel
-void testmetal() {
-    // Create a device
-    NSArray <id<MTLDevice>>* mtl_devices = MTLCopyAllDevices();
-    assert(mtl_devices.count > 0);
-    id<MTLDevice> device = mtl_devices[0];
+static id<MTLDevice> device;
+
+void init_metal(void) {
+    NSArray<id<MTLDevice>>* devices = MTLCopyAllDevices();
+    assert(devices.count > 0);
+
+    device = devices[0];
+}
+
+void* upload_metal(void* host, size_t size) {
+    assert(device);
+    id<MTLBuffer> buffer = [device newBufferWithBytes:host length:size options:MTLResourceStorageModeShared];
+    return buffer;
+}
+
+void prepare_metal(struct Transformer* transformer) {
+    assert(device);
+    printf("# Metal: %s\n", device.name.UTF8String);
 
     dispatch_data_t lib_data = dispatch_data_create(infer_metallib, infer_metallib_len, dispatch_get_main_queue(), ^{});
     
@@ -66,3 +80,6 @@ void testmetal() {
     }
 }
 
+float* forward_metal(struct Transformer* transformer, int token, int pos, unsigned flags) {
+    return NULL;
+}

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -1,10 +1,9 @@
 #include <metal_stdlib>
 using namespace metal;
 
-kernel void kernel_basic(
-    constant float& scale [[buffer(0)]],
-    device float* input [[buffer(1)]],
-    device float* output [[buffer(2)]],
-    uint id [[thread_position_in_grid]]) {
-    output[id] = input[id] * scale;
+template <typename T>
+kernel void kernel_embed(constant int& token_offset [[buffer(0)]], device float* o [[buffer(1)]], device T* weight [[buffer(2)]], uint id [[thread_position_in_grid]]) {
+	o[id] = weight[id + token_offset];
 }
+
+template [[host_name("embed_half")]] kernel void kernel_embed<half>(constant int&, device float*, device half*, uint);

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -115,7 +115,7 @@ kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[b
 	int q_dim = args.q_dim;
 	int kv_dim = args.kv_dim;
 
-	int j = id / warpSize;
+	int j = (id / warpSize) * 2;
 	device T* w = j < q_dim ? wq : (j < q_dim + kv_dim ? wk : wv);
 	int k = j < q_dim ? j : (j < q_dim + kv_dim ? j - q_dim : j - q_dim - kv_dim);
 

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -1,8 +1,18 @@
 #include <metal_stdlib>
+#include <metal_compute>
 #include <metal_simdgroup>
 using namespace metal;
 
 static constant int warpSize = 32;
+
+inline float blockreduce_sum(threadgroup float* vs, float val, uint id) {
+	val = simd_sum(val);
+
+	vs[id / warpSize] = val;
+	threadgroup_barrier(mem_flags::mem_threadgroup);
+
+	return simd_sum(vs[id % warpSize]);
+}
 
 inline float matmul_warppar(device float* x, device half* w, int i, int n, uint id) {
 	int lane = id % warpSize;
@@ -22,6 +32,48 @@ kernel void kernel_embed(constant int& token_offset [[buffer(0)]], device float*
 }
 
 template [[host_name("embed_half")]] kernel void kernel_embed<half>(constant int&, device float*, device half*, uint);
+
+struct NormArgs {
+	int size;
+	float eps;
+	bool ln;
+};
+
+[[host_name("rmsnorm")]] kernel void kernel_rmsnorm(constant NormArgs& args [[buffer(0)]], device float* o [[buffer(1)]], device float* x [[buffer(2)]], device float* weight [[buffer(3)]], uint id [[thread_position_in_grid]]) {
+	int i = id;
+	const int blockSize = 1024;
+	int size = args.size;
+
+	threadgroup float vs[32];
+
+	float mean = 0.0f;
+	if (args.ln) {
+		// calculate sum (per thread)
+		float sum = 0.0f;
+		for (int j = i; j < size; j += blockSize) {
+			sum += x[j];
+		}
+
+		// sum across threads in block
+		mean = blockreduce_sum(vs, sum, id) / size;
+	}
+
+	// calculate sum of squares (per thread)
+	float ss = 0.0f;
+	for (int j = i; j < size; j += blockSize) {
+		float v = x[j] - mean;
+		ss += v * v;
+	}
+
+	// sum across threads in block
+	ss = blockreduce_sum(vs, ss, id);
+
+	float scale = rsqrt(ss / size + args.eps);
+
+	for (int j = i; j < size; j += blockSize) {
+		o[j] = (x[j] - mean) * weight[j] * scale;
+	}
+}
 
 template <typename T>
 kernel void kernel_output(constant int& n [[buffer(0)]], device float* xout [[buffer(1)]], device float* x [[buffer(2)]], device T* w [[buffer(3)]], uint id [[thread_position_in_grid]]) {

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -110,7 +110,7 @@ struct QkvArgs {
 };
 
 template <typename T, typename KVT>
-kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[buffer(1)]], device float* qout [[buffer(2)]], device KVT* keyc [[buffer(3)]], device KVT* valc [[buffer(4)]], device T* wq [[buffer(5)]], device T* wk [[buffer(6)]], device T* wv [[buffer(7)]], device float* bqkv [[buffer(8)]], uint id [[thread_position_in_grid]]) {
+kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[buffer(1)]], device float* qout [[buffer(2)]], device KVT* keyc [[buffer(3)]], device KVT* valc [[buffer(4)]], device T* wq [[buffer(5)]], device T* wk [[buffer(6)]], device T* wv [[buffer(7)]], uint id [[thread_position_in_grid]]) {
 	int dim = args.dim;
 	int q_dim = args.q_dim;
 	int kv_dim = args.kv_dim;
@@ -121,11 +121,6 @@ kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[b
 
 	float v0 = matmul_warppar(x, w, k + 0, dim, id);
 	float v1 = matmul_warppar(x, w, k + 1, dim, id);
-
-	if (bqkv) {
-		v0 += bqkv[j + 0];
-		v1 += bqkv[j + 1];
-	}
 
 	v0 = min(max(v0, -args.qkv_clip), args.qkv_clip);
 	v1 = min(max(v1, -args.qkv_clip), args.qkv_clip);
@@ -152,7 +147,7 @@ kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[b
 	}
 }
 
-template [[host_name("qkv_half_half")]] kernel void kernel_qkv<half, half>(constant QkvArgs&, device float*, device float*, device half*, device half*, device half*, device half*, device half*, device float*, uint);
+template [[host_name("qkv_half_half")]] kernel void kernel_qkv<half, half>(constant QkvArgs&, device float*, device float*, device half*, device half*, device half*, device half*, device half*, uint);
 
 inline float4 attn_load4(device half* p) {
 	return float4(*(device half4*)p);

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -63,14 +63,17 @@ inline float matmul_warppar(device float* x, device uint32_t* w, int i, int n, u
 		float4 xx0 = *(device float4*)&x[j];
 		float4 xx1 = *(device float4*)&x[j + 4];
 
-		val += gf4_ff(wg, 0) * xx0.x;
-		val += gf4_ff(wg, 1) * xx0.y;
-		val += gf4_ff(wg, 2) * xx0.z;
-		val += gf4_ff(wg, 3) * xx0.w;
-		val += gf4_ff(wg, 4) * xx1.x;
-		val += gf4_ff(wg, 5) * xx1.y;
-		val += gf4_ff(wg, 6) * xx1.z;
-		val += gf4_ff(wg, 7) * xx1.w;
+		float us = as_type<half>(uint16_t(wg << 8));
+		float s = us * -0.25f;
+
+		val += (float(int(wg >>  8) & 7) * s + us) * xx0.x;
+		val += (float(int(wg >> 11) & 7) * s + us) * xx0.y;
+		val += (float(int(wg >> 14) & 7) * s + us) * xx0.z;
+		val += (float(int(wg >> 17) & 7) * s + us) * xx0.w;
+		val += (float(int(wg >> 20) & 7) * s + us) * xx1.x;
+		val += (float(int(wg >> 23) & 7) * s + us) * xx1.y;
+		val += (float(int(wg >> 26) & 7) * s + us) * xx1.z;
+		val += (float(int(wg >> 29) & 7) * s + us) * xx1.w;
 	}
 	return simd_sum(val);
 }

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -1,5 +1,20 @@
 #include <metal_stdlib>
+#include <metal_simdgroup>
 using namespace metal;
+
+static constant int warpSize = 32;
+
+inline float matmul_warppar(device float* x, device half* w, int i, int n, uint id) {
+	int lane = id % warpSize;
+	float val = 0.0f;
+	for (int j = lane * 2; j < n; j += warpSize * 2) {
+		float2 ww = float2(*(device half2*)&w[i * n + j]);
+		float2 xx = *(device float2*)&x[j];
+		val += ww.x * xx.x;
+		val += ww.y * xx.y;
+	}
+	return simd_sum(val);
+}
 
 template <typename T>
 kernel void kernel_embed(constant int& token_offset [[buffer(0)]], device float* o [[buffer(1)]], device T* weight [[buffer(2)]], uint id [[thread_position_in_grid]]) {
@@ -7,3 +22,15 @@ kernel void kernel_embed(constant int& token_offset [[buffer(0)]], device float*
 }
 
 template [[host_name("embed_half")]] kernel void kernel_embed<half>(constant int&, device float*, device half*, uint);
+
+template <typename T>
+kernel void kernel_output(constant int& n [[buffer(0)]], device float* xout [[buffer(1)]], device float* x [[buffer(2)]], device T* w [[buffer(3)]], uint id [[thread_position_in_grid]]) {
+	int j = id / warpSize;
+	float val = matmul_warppar(x, w, j, n, id);
+
+	if (id % warpSize == 0) {
+		xout[j] = val;
+	}
+}
+
+template [[host_name("output_half")]] kernel void kernel_output<half>(constant int&, device float*, device float*, device half*, uint);

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -210,7 +210,7 @@ struct QkvArgs {
 };
 
 template <typename T, typename KVT>
-kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[buffer(1)]], device float* qout [[buffer(2)]], device KVT* keyc [[buffer(3)]], device KVT* valc [[buffer(4)]], device T* wq [[buffer(5)]], device T* wk [[buffer(6)]], device T* wv [[buffer(7)]], uint id [[thread_position_in_grid]]) {
+kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[buffer(1)]], device float* qout [[buffer(2)]], device KVT* keyc [[buffer(3)]], device KVT* valc [[buffer(4)]], device T* wq [[buffer(5)]], device T* wk [[buffer(6)]], device T* wv [[buffer(7)]], device float* bqkv [[buffer(8)]], uint id [[thread_position_in_grid]]) {
 	int dim = args.dim;
 	int q_dim = args.q_dim;
 	int kv_dim = args.kv_dim;
@@ -221,6 +221,9 @@ kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[b
 
 	float v0 = matmul_warppar(x, w, k + 0, dim, id);
 	float v1 = matmul_warppar(x, w, k + 1, dim, id);
+
+	v0 += bqkv[j + 0];
+	v1 += bqkv[j + 1];
 
 	v0 = min(max(v0, -args.qkv_clip), args.qkv_clip);
 	v1 = min(max(v1, -args.qkv_clip), args.qkv_clip);
@@ -247,9 +250,9 @@ kernel void kernel_qkv(constant QkvArgs& args [[buffer(0)]], device float* x [[b
 	}
 }
 
-template [[host_name("qkv_half_half")]] kernel void kernel_qkv<half, half>(constant QkvArgs&, device float*, device float*, device half*, device half*, device half*, device half*, device half*, uint);
-template [[host_name("qkv_fp8_half")]] kernel void kernel_qkv<uint8_t, half>(constant QkvArgs&, device float*, device float*, device half*, device half*, device uint8_t*, device uint8_t*, device uint8_t*, uint);
-template [[host_name("qkv_gf4_half")]] kernel void kernel_qkv<uint32_t, half>(constant QkvArgs&, device float*, device float*, device half*, device half*, device uint32_t*, device uint32_t*, device uint32_t*, uint);
+template [[host_name("qkv_half_half")]] kernel void kernel_qkv<half, half>(constant QkvArgs&, device float*, device float*, device half*, device half*, device half*, device half*, device half*, device float*, uint);
+template [[host_name("qkv_fp8_half")]] kernel void kernel_qkv<uint8_t, half>(constant QkvArgs&, device float*, device float*, device half*, device half*, device uint8_t*, device uint8_t*, device uint8_t*, device float*, uint);
+template [[host_name("qkv_gf4_half")]] kernel void kernel_qkv<uint32_t, half>(constant QkvArgs&, device float*, device float*, device half*, device half*, device uint32_t*, device uint32_t*, device uint32_t*, device float*, uint);
 
 inline float4 attn_load4(device half* p) {
 	return float4(*(device half4*)p);

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -72,7 +72,7 @@ struct NormArgs {
 		}
 
 		// sum across threads in block
-		mean = blockreduce_sum(vs, sum, id) / size;
+		mean = blockreduce_sum(vs, sum, i) / size;
 	}
 
 	// calculate sum of squares (per thread)
@@ -83,7 +83,7 @@ struct NormArgs {
 	}
 
 	// sum across threads in block
-	ss = blockreduce_sum(vs, ss, id);
+	ss = blockreduce_sum(vs, ss, i);
 
 	float scale = rsqrt(ss / size + args.eps);
 
@@ -251,7 +251,7 @@ template [[host_name("attn_score_half")]] kernel void kernel_attn_score<half>(co
 	}
 
 	// max across threads in block
-	max_val = blockreduce_max(vs, max_val, id);
+	max_val = blockreduce_max(vs, max_val, i);
 
 	// exp per thread
 	for (int j = i; j < size; j += blockSize) {

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -1,0 +1,10 @@
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void kernel_basic(
+    device float* input [[buffer(0)]],
+                               device float* output [[buffer(1)]],
+                               constant float& scale [[buffer(2)]],
+                               uint id [[thread_position_in_grid]]) {
+    output[id] = input[id] * scale;
+}

--- a/src/infer.metal
+++ b/src/infer.metal
@@ -2,9 +2,9 @@
 using namespace metal;
 
 kernel void kernel_basic(
-    device float* input [[buffer(0)]],
-                               device float* output [[buffer(1)]],
-                               constant float& scale [[buffer(2)]],
-                               uint id [[thread_position_in_grid]]) {
+    constant float& scale [[buffer(0)]],
+    device float* input [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    uint id [[thread_position_in_grid]]) {
     output[id] = input[id] * scale;
 }

--- a/src/run.c
+++ b/src/run.c
@@ -28,6 +28,8 @@ void prepare_cuda(struct Transformer* transformer);
 float* forward_cuda(struct Transformer* transformer, int token, int pos, unsigned flags);
 void perf_cuda(void);
 
+void testmetal(void);
+
 void get_config(struct Config* config, struct Tensors* tensors, int context) {
 	config->dim = atoi(tensors_metadata(tensors, "dim"));
 	config->hidden_dim = atoi(tensors_metadata(tensors, "hidden_dim"));
@@ -484,6 +486,11 @@ int main(int argc, char* argv[]) {
 	bool cuda = !cpu || atoi(cpu) == 0;
 #endif
 
+#ifdef __APPLE__
+	char* cpu = getenv("CALM_CPU");
+	bool metal = !cpu || atoi(cpu) == 0;
+#endif
+
 	// read .safetensors model
 	struct Tensors tensors = {};
 	if (tensors_open(&tensors, checkpoint_path) != 0) {
@@ -540,6 +547,12 @@ int main(int argc, char* argv[]) {
 	if (cuda) {
 		prepare_cuda(&transformer);
 		transformer.forward = forward_cuda;
+	}
+#endif
+
+#ifdef __APPLE__
+	if (metal) {
+		testmetal();
 	}
 #endif
 


### PR DESCRIPTION
This change adds a Metal implementation for macOS; it's 95% functionally complete - it's missing mixture-of-experts - but hasn't been fully tuned for performance. On M1 base it's reaching ~91% bandwidth for fp16/fp8 models and ~65% for gf4 weights (on Mistral 7B).